### PR TITLE
Remove temporary intermediate realization calculation files

### DIFF
--- a/consequences-rlz-000_137.csv
+++ b/consequences-rlz-000_137.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:845c654155d7dc90bfe8911ac6ccfeb385720544c5cb4eb352f3ff006dfc214d
-size 52907727

--- a/consequences-rlz-001_137.csv
+++ b/consequences-rlz-001_137.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4b897a7a48e70248e080e292a2a51aa66ce3b547cb52fa919c0634f7c7097c22
-size 52936155

--- a/consequences-rlz-002_137.csv
+++ b/consequences-rlz-002_137.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:927896c77ca3e8687db6c1e28e4770ef51c870eaf9c69c426ecc8fe949b4d396
-size 23419139

--- a/temp/avg_damages-rlz-000_137.csv
+++ b/temp/avg_damages-rlz-000_137.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:80d642edf1adda3a99ac3757b3f7ca3323b008a486d6a441b5a264bcec661bb3
-size 97733382

--- a/temp/avg_damages-rlz-001_137.csv
+++ b/temp/avg_damages-rlz-001_137.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eb743cd6b9a0fdf99ddf45c967c9ce90c2a83bc0f13f10eb83a44254ab987c50
-size 97733382

--- a/temp/avg_damages-rlz-002_137.csv
+++ b/temp/avg_damages-rlz-002_137.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9550d38fce9d92525a9abc952e9d033100f974e7ef598754a8fa7a30a3125824
-size 97733382

--- a/temp/avg_damages-rlz-003_137.csv
+++ b/temp/avg_damages-rlz-003_137.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd3987e89faba7f9ff1f5b625b2cd34fcea1c0f5d327764cc9cac98d477794d5
-size 97733382

--- a/temp/realizations_137.csv
+++ b/temp/realizations_137.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9ef27b6182954b2b5bb5944c737feb6ae91010fc350e9d5c3714aa53d99add97
-size 311

--- a/temp_projectwork/consequences-rlz-000_135.csv
+++ b/temp_projectwork/consequences-rlz-000_135.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c59225b9cd6b7faea60026537b6caf52cee862e3ca91de29047ed6533714392
-size 52912267

--- a/temp_projectwork/consequences-rlz-001_135.csv
+++ b/temp_projectwork/consequences-rlz-001_135.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bbe3526b1f9dca5ec41ce2fbe6881df49cc1951f3764870d644e55f464a03ed0
-size 52908911

--- a/temp_projectwork/consequences-rlz-002_135.csv
+++ b/temp_projectwork/consequences-rlz-002_135.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7faaa8a1ead5e4942df1e62d9fd20122d52ce0f082f7797bb044e8997a4f7f89
-size 52912208

--- a/temp_projectwork/consequences-rlz-003_135.csv
+++ b/temp_projectwork/consequences-rlz-003_135.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3864719ff02394ca5ad49a5470c6c00972105e0c3a2a034264f9fd657dcb2906
-size 52914509


### PR DESCRIPTION
Hi @tieganh!

I notice the following CSV files which seems to be temporary intermediate realization calculation files that were added in commit  37f8cae8ed3924b6e6dead34b3923ce2a69f953f "edits to scenario calculation scheme, adding draft manual":

```
consequences-rlz-000_137.csv
consequences-rlz-001_137.csv
consequences-rlz-002_137.csv
temp/avg_damages-rlz-000_137.csv
temp/avg_damages-rlz-001_137.csv
temp/avg_damages-rlz-002_137.csv
temp/avg_damages-rlz-003_137.csv
temp/realizations_137.csv
temp_projectwork/consequences-rlz-000_135.csv
temp_projectwork/consequences-rlz-001_135.csv
temp_projectwork/consequences-rlz-002_135.csv
temp_projectwork/consequences-rlz-003_135.csv
```

I am guessing that they CSV files inadvertently committed, hence this pull request to remove them; but I could definitely be wrong too.  Please review and let me know, and either merge or discard this PR.

Many thanks!