### PR TITLE
generate_assets.yml: Fix "Cannot upload assets for release..."

### DIFF
--- a/.github/workflows/generate_assets.yml
+++ b/.github/workflows/generate_assets.yml
@@ -1,25 +1,40 @@
-name: Create release assets
+name: Upload release assets
 
 on:
-  #push:
-    #branches:
-      #- master
-  release:
-    types: [released]
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag"
+        required: true
 
 jobs:
-  build:
+  upload-release-assets:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
-        uses: actions/checkout@v2
+      - name: Make more room by deleting unused software
+        run: |
+          set -x
+          df -h
+          du -csh /usr/share/dotnet
+          du -csh /usr/local/lib/android
+          sudo eatmydata rm -f -r /usr/share/dotnet
+          sudo eatmydata rm -f -r /usr/local/lib/android
+          df -h
+
+      - name: Checkout earthquake-scenarios repository
+        uses: actions/checkout@v3
         with:
           lfs: 'true'
-      - name: upload assets
-        uses: AButler/upload-release-assets@v2.0
+
+      - name: Upload FINISHED CSV and GeoPackage files as release assets
+        uses: xresloader/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: 'FINISHED/geopackages/*;FINISHED/*.csv'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          # To add assets to an existing release, use below line with release tag, then run action from actions page
-          #release-tag: v1.1.0
+          file: 'FINISHED/geopackages/*;FINISHED/*.csv'
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || '' }}
+          tags: true
+          draft: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.2] - 2023-04-20
+
+### Fixed
+
+- Update FINISHED/geopackages/shakemap_scenario_extents.zip
+  to match the current 9 scenarios with the 3 renames
+- Fix automated upload of release assets
+
 ## [1.2.1] - 2023-04-18
 
 ### Added
@@ -51,7 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - ACM7p3_LeechRiverFullFault
   - IDM7p1_Sidney
 
-[Unreleased]: https://github.com/OpenDRR/earthquake-scenarios/compare/v1.2.1...HEAD
+[Unreleased]: https://github.com/OpenDRR/earthquake-scenarios/compare/v1.2.2...HEAD
+[1.2.2]: https://github.com/OpenDRR/earthquake-scenarios/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/OpenDRR/earthquake-scenarios/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/OpenDRR/earthquake-scenarios/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/OpenDRR/earthquake-scenarios/compare/v1.0...v1.1.0

--- a/FINISHED/geopackages/shakemap_scenario_extents.zip
+++ b/FINISHED/geopackages/shakemap_scenario_extents.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6edbf9fe48e7da172c7d03f40f14fb614ced2e07a11f9119e07e965ace6c58d5
-size 36119
+oid sha256:6e29c415e592ed8be487fca38dfd5a90b244d5f5ced7d4ccdf73869f36e9f961
+size 57314


### PR DESCRIPTION
Switch to xresloader/upload-to-github-release@v1, changed push trigger and add an input field for release tag for manual trigger, to try to resolve the following error when release v1.2.1 was published:

    Run AButler/upload-release-assets@v2.0
    Warning: Cannot upload assets for release which is being released

See https://github.com/OpenDRR/earthquake-scenarios/actions/runs/4737851962/jobs/8411089719 for the error message in context before the workflow log expires.

Also upgrade to actions/checkout@v3, and delete Android and .NET files inside ubuntu-22.04 runner to make more room.