### PR TITLE
Use easimon/maximize-build-space for the upload_assets.yml workflow

### DIFF
--- a/.github/workflows/upload_assets.yml
+++ b/.github/workflows/upload_assets.yml
@@ -14,20 +14,28 @@ jobs:
   upload-release-assets:
     runs-on: ubuntu-latest
     steps:
-      - name: Make more room by deleting unused software
-        run: |
-          set -x
-          df -h
-          du -csh /usr/share/dotnet
-          du -csh /usr/local/lib/android
-          sudo eatmydata rm -f -r /usr/share/dotnet
-          sudo eatmydata rm -f -r /usr/local/lib/android
-          df -h
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 512
+          swap-size-mb: 1024
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
 
       - name: Checkout earthquake-scenarios repository
         uses: actions/checkout@v3
         with:
           lfs: 'true'
+
+      - name: Check disk usage
+        run: |
+          du -csh .git/*
+          du -csh FINISHED/geopackages/*
+          du -csh FINISHED/*.csv
+          du -csh .
 
       - name: Upload FINISHED CSV and GeoPackage files as release assets
         uses: xresloader/upload-to-github-release@v1


### PR DESCRIPTION
(renamed from generate_assets.yml)

Hope it does not run out of disk space again for our 22 scenarios!

_Just_ enough space, see the build log at https://github.com/anthonyfok/earthquake-scenarios/actions/runs/5833684124/job/15821634542
And sample release with assets at https://github.com/anthonyfok/earthquake-scenarios/releases/tag/v1.2.4-rc1
Glad that it worked!

I guess we'll think of other strategies for future additions, i.e. multiple partial checkouts, haha!

Cheers,
Anthony