### PR TITLE
Fix remaining issues for v1.4.4 map tiles display, etc.

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -2,10 +2,16 @@
 
 source "https://rubygems.org"
 
+gem 'wdm', '~> 0.1.1', :install_if => Gem.win_platform?
+
+gem "webrick"
+
+platforms :mingw, :x64_mingw, :mswin, :jruby do
+  gem 'tzinfo', '>= 1', '< 3'
+  gem 'tzinfo-data'
+end
+
 group :jekyll_plugins do
   gem "github-pages"
   gem "jekyll-github-metadata"
-  gem 'tzinfo-data'
-  gem "webrick"
-  gem 'wdm', '>= 0.1.0' if Gem.win_platform?
 end

--- a/docs/_pages/en/dsra_scenario_map.md
+++ b/docs/_pages/en/dsra_scenario_map.md
@@ -1,7 +1,7 @@
 ---
 authorName: Natural Resources Canada
 authorUrl:
-dateModified: 2024-02-20
+dateModified: 2024-02-21
 noContentTitle: true
 pageclass: wb-prettify all-pre
 subject:
@@ -91,9 +91,9 @@ crossorigin=""></script>
       shakemapProp = 'sH_PGA_max', // Property for shakemap popup
       scenarioProp = 'sCt_Res90_b0', // Property for popup and feature colour
       shakeCurrent = true,
-      epicenter,
+      epicentre,
       selection = 0; // Id of a selected feature
-    
+
 
   L.tileLayer( 'https://osm-{s}.gs.mil/tiles/default_pc/{z}/{x}/{y}.png', {
       subdomains: '1234',
@@ -168,7 +168,7 @@ crossorigin=""></script>
       }).on( 'load', function () {
         // Remove loading modal
         $( '#modal' ).remove();
-        epicenter.bringToFront();
+        epicentre.bringToFront();
       });
 
     var shakeLayer1km = L.vectorGrid.protobuf( shakemapUrl1, shakeTileOptions( 1 ) )
@@ -179,7 +179,7 @@ crossorigin=""></script>
       }).on( 'load', function () {
         // Remove loading modal
         $( '#modal' ).remove();
-        epicenter.bringToFront();
+        epicentre.bringToFront();
       }).on( 'click', function ( e ) {
     	  L.popup().setContent( "<strong>{% if page.lang == 'en' %}PGA: {% else %}AMS: {% endif %}</strong>" + e.layer.properties.sH_PGA_max.toLocaleString( undefined, { maximumFractionDigits: 2 }) )
           .setLatLng( e.latlng )
@@ -194,7 +194,7 @@ crossorigin=""></script>
       }).on( 'load', function () {
         // Remove loading modal
         $( '#modal' ).remove();
-        epicenter.bringToFront();
+        epicentre.bringToFront();
       }).on( 'click', function ( e ) {
     	  L.popup().setContent( "<strong>{% if page.lang == 'en' %}PGA: {% else %}AMS: {% endif %}</strong>" + e.layer.properties.sH_PGA_max.toLocaleString( undefined, { maximumFractionDigits: 2 }) )
           .setLatLng( e.latlng )
@@ -382,7 +382,7 @@ crossorigin=""></script>
         }
 
         div.innerHTML +=
-            '<br><div>🔴 <b>{% if page.lang == 'en' %}Epicenter{% else %}Épicentre{% endif %}</b></div>';
+            '<br><div>🔴 <b>{% if page.lang == 'en' %}Epicentre{% else %}Épicentre{% endif %}</b></div>';
       }
 
       else {
@@ -399,7 +399,7 @@ crossorigin=""></script>
         }
 
         div.innerHTML +=
-            '<br><div>🔴 <b>{% if page.lang == 'en' %}Epicenter{% else %}Épicentre{% endif %}</b></div>';
+            '<br><div>🔴 <b>{% if page.lang == 'en' %}Epicentre{% else %}Épicentre{% endif %}</b></div>';
       }
 
       return div;
@@ -457,122 +457,122 @@ function setBounds() {
         "acm7p0_georgiastraitfault": {
             southWest: [48.30891568684188, -129.0949439967106],
             northEast: [53.53110877480622, -117.3589501128889],
-            epicenter: [49.243365, -123.62296]
+            epicentre: [49.243365, -123.62296]
         },
         "acm7p3_leechriverfullfault": {
             southWest: [48.30891568624434, -129.0949439967106],
             northEast: [53.30903267135562, -117.4908738038378],
-            epicenter: [48.407017, -123.412134]
+            epicentre: [48.407017, -123.412134]
         },
         "sim9p0_cascadiainterfacebestfault": {
             southWest: [48.30891568684188, -139.0522010412872],
             northEast: [60.00006153221153, -114.05375826483],
-            epicenter: [48.251246, -125.215269]
+            epicentre: [48.251246, -125.215269]
         },
         "scm7p5_valdesbois": {
             southWest: [42.47260780141163, -86.54942531485392],
             northEast: [55.00064603767294, -67.44787497495167],
-            epicenter: [45.905377, -75.494669]   
+            epicentre: [45.905377, -75.494669]
         },
         "idm7p1_sidney": {
             southWest: [48.30891568684188, -129.0949439967106],
             northEast: [53.30903267135562, -117.3589501128889],
-            epicenter: [48.618961, -123.299385] 
+            epicentre: [48.618961, -123.299385]
         },
         "acm4p9_georgiastraitfault": {
             southWest: [48.30891568684188, -129.0949439967106],
             northEast: [53.53110877480622, -117.3589501128889],
-            epicenter: [49.280, -123.340] 
-        },    
+            epicentre: [49.280, -123.340]
+        },
         "acm7p4_denalifault": {
             southWest: [60.00000000710405, -141.0180731580253],
             northEast: [69.64745530351352, -123.7893248352215],
-            epicenter: [61.200 , -138.780] 
-        },  
+            epicentre: [61.200 , -138.780]
+        },
         "scm5p0_montreal": {
             southWest: [42.53884243059241, -86.54942531485392],
             northEast: [55.00064603767294, -65.94908207524423],
-            epicenter: [45.500 , -73.600] 
-        }, 
+            epicentre: [45.500 , -73.600]
+        },
         "scm5p5_constancebay": {
             southWest: [42.06164244999297, -86.54942531485392],
             northEast: [55.00064603767294, -68.38243594858385],
-            epicenter: [45.500 , -76.060] 
-        },              
+            epicentre: [45.500 , -76.060]
+        },
         "acm4p9_vedderfault": {
             southWest: [48.30891418, -127.9421387],
             northEast: [53.53110886, -116.2564392],
-            epicenter: [49.04, -122.08] 
-        },  
+            epicentre: [49.04, -122.08]
+        },
         "acm5p0_georgiastraitfault": {
             southWest: [48.30891418, -129.0949554],
             northEast: [53.53110886, -117.2290878],
-            epicenter: [49.28, -123.34] 
+            epicentre: [49.28, -123.34]
         },
         "acm5p0_mysterylake": {
             southWest: [48.30891418, -129.0949554],
             northEast: [53.53110877, -116.8056259],
-            epicenter: [49.37, -122.92] 
-        },   
+            epicentre: [49.37, -122.92]
+        },
         "acm5p2_beaufortfault": {
             southWest: [48.30891569, -129.094944],
             northEast: [53.53110877, -118.7975574],
-            epicenter: [49.33, -124.84] 
-        },    
+            epicentre: [49.33, -124.84]
+        },
         "acm5p2_vedderfault": {
             southWest: [48.30891569, -127.9421269],
             northEast: [53.53110877, -116.2564537],
-            epicenter: [49.04, -122.08] 
-        },      
+            epicentre: [49.04, -122.08]
+        },
         "acm5p5_southeypoint": {
             southWest: [48.30891569, -129.094944],
             northEast: [53.53110877, -117.4908738],
-            epicenter: [48.95, -123.61] 
-        },        
+            epicentre: [48.95, -123.61]
+        },
         "acm5p7_southeypoint": {
             southWest: [48.30891569, -129.094944],
             northEast: [53.53110877, -117.4908738],
-            epicenter: [48.95, -123.61] 
-        },     
+            epicentre: [48.95, -123.61]
+        },
         "acm7p7_queencharlottefault": {
             southWest: [50.11540505, -133.1977449],
             northEast: [56.27162148, -124.9961029],
-            epicenter: [53, -132.62] 
-        },   
+            epicentre: [53, -132.62]
+        },
         "acm8p0_queencharlottefault": {
             southWest: [49.51322353, -133.1977449],
             northEast: [58.00055135, -124.9961029],
-            epicenter: [53, -132.62] 
-        },  
+            epicentre: [53, -132.62]
+        },
         "scm5p0_burlingtontorontostructuralzone": {
             southWest: [41.68143543, -86.54942531],
             northEast: [52.29313064, -71.892560649],
-            epicenter: [43.49, -79.47] 
-        },  
+            epicentre: [43.49, -79.47]
+        },
         "scm5p0_rougebeach": {
             southWest: [41.68143543, -86.54942531],
             northEast: [55.00064604, -69.99999997],
-            epicenter: [43.78, -79.09] 
-        },  
+            epicentre: [43.78, -79.09]
+        },
         "scm5p6_gloucesterfault": {
             southWest: [42.06164245, -86.54942531],
             northEast: [55.00064604, -68.38243595],
-            epicenter: [43.78, -79.09] 
-        },  
+            epicentre: [43.78, -79.09]
+        },
         "scm5p9_millesilesfault": {
             southWest: [42.53884243, -86.54942531],
             northEast: [55.00064604, -65.94908208],
-            epicenter: [45.607, -73.82] 
-        },  
+            epicentre: [45.607, -73.82]
+        },
     };
 
     const config = scenarioConfig[lcScenario];
     if (config) {
-        const { southWest, northEast, epicenter } = config;
+        const { southWest, northEast, epicentre } = config;
 
         const bounds = L.latLngBounds(L.latLng(...southWest), L.latLng(...northEast));
-        const epicenterMarker = L.circleMarker(epicenter, circleStyle()).addTo(map);
-        map.setView(L.latLng(...epicenter), 7);
+        const epicentreMarker = L.circleMarker(epicentre, circleStyle()).addTo(map);
+        map.setView(L.latLng(...epicentre), 7);
     }
 }
 
@@ -641,71 +641,71 @@ function setShakeLayerStyles(z) {
         "acm4p9_georgiastraitfault": {
             1: "dsra_acm4p9_georgiastraitfault_shakemap_hexgrid_1km",
             5: "dsra_acm4p9_georgiastraitfault_shakemap_hexgrid_5km"
-        },        
+        },
         "acm7p4_denalifault": {
             1: "dsra_acm7p4_denalifault_shakemap_hexgrid_1km",
             5: "dsra_acm7p4_denalifault_shakemap_hexgrid_5km"
-        },        
+        },
         "scm5p0_montreal": {
             1: "dsra_scm5p0_montreal_shakemap_hexgrid_1km",
             5: "dsra_scm5p0_montreal_shakemap_hexgrid_5km"
-        },        
+        },
         "scm5p5_constancebay": {
             1: "dsra_scm5p5_constancebay_shakemap_hexgrid_1km",
             5: "dsra_scm5p5_constancebay_shakemap_hexgrid_5km"
-        },        
+        },
         "acm4p9_vedderfault": {
             1: "dsra_acm4p9_vedderfault_shakemap_hexgrid_1km",
             5: "dsra_acm4p9_vedderfault_shakemap_hexgrid_5km"
-        },        
+        },
         "acm5p0_georgiastraitfault": {
             1: "dsra_acm5p0_georgiastraitfault_shakemap_hexgrid_1km",
             5: "dsra_acm5p0_georgiastraitfault_shakemap_hexgrid_5km"
-        },        
+        },
         "acm5p0_mysterylake": {
             1: "dsra_acm5p0_mysterylake_shakemap_hexgrid_1km",
             5: "dsra_acm5p0_mysterylake_shakemap_hexgrid_5km"
-        },        
+        },
         "acm5p2_beaufortfault": {
             1: "dsra_acm5p2_beaufortfault_shakemap_hexgrid_1km",
             5: "dsra_acm5p2_beaufortfault_shakemap_hexgrid_5km"
-        },        
+        },
         "acm5p2_vedderfault": {
             1: "dsra_acm5p2_vedderfault_shakemap_hexgrid_1km",
             5: "dsra_acm5p2_vedderfault_shakemap_hexgrid_5km"
-        },        
+        },
         "acm5p5_southeypoint": {
             1: "dsra_acm5p5_southeypoint_shakemap_hexgrid_1km",
             5: "dsra_acm5p5_southeypoint_shakemap_hexgrid_5km"
-        },        
+        },
         "acm5p7_southeypoint": {
             1: "dsra_acm5p7_southeypoint_shakemap_hexgrid_1km",
             5: "dsra_acm5p7_southeypoint_shakemap_hexgrid_5km"
-        },        
+        },
         "acm7p7_queencharlottefault": {
             1: "dsra_acm7p7_queencharlottefault_shakemap_hexgrid_1km",
             5: "dsra_acm7p7_queencharlottefault_shakemap_hexgrid_5km"
-        },        
+        },
         "acm8p0_queencharlottefault": {
             1: "dsra_acm8p0_queencharlottefault_shakemap_hexgrid_1km",
             5: "dsra_acm8p0_queencharlottefault_shakemap_hexgrid_5km"
-        },    
+        },
         "scm5p0_burlingtontorontostructuralzone": {
             1: "dsra_scm5p0_burlingtontorontostructuralzone_shakemap_hexgrid_1km",
             5: "dsra_scm5p0_burlingtontorontostructuralzone_shakemap_hexgrid_5km"
-        },            
+        },
         "scm5p0_rougebeach": {
             1: "dsra_scm5p0_rougebeach_shakemap_hexgrid_1km",
             5: "dsra_scm5p0_rougebeach_shakemap_hexgrid_5km"
-        },        
+        },
         "scm5p6_gloucesterfault": {
             1: "dsra_scm5p6_gloucesterfault_shakemap_hexgrid_1km",
             5: "dsra_scm5p6_gloucesterfault_shakemap_hexgrid_5km"
-        },        
+        },
         "scm5p9_millesilesfault": {
             1: "dsra_scm5p9_millesilesfault_shakemap_hexgrid_1km",
             5: "dsra_scm5p9_millesilesfault_shakemap_hexgrid_5km"
-        },   
+        },
     };
 
     const scenarioStyles = scenarios[lcScenario];

--- a/docs/_pages/en/dsra_scenario_map.md
+++ b/docs/_pages/en/dsra_scenario_map.md
@@ -23,14 +23,21 @@ breadcrumbs:
   - title: "Earthquake Scenario Map"
 ---
 <!-- Load Leaflet from CDN -->
-<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
+integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
+crossorigin=""/>
+
+<script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"
+integrity="sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA=="
+crossorigin=""></script>
 
 <!-- Load Esri Leaflet from CDN -->
-<script src="https://unpkg.com/esri-leaflet@3.0.10/dist/esri-leaflet.js" integrity="sha512-i9mZ/0lnBMdKZjkVQXImtZbWzrhomyyQzXarfT4ki1eD/Bi+rcV4lFyzX52lbRQtqj070JQea4p8QNCMrHzuYg==" crossorigin=""></script>
+<script src="https://unpkg.com/esri-leaflet@3.0.2/dist/esri-leaflet.js"
+integrity="sha512-myckXhaJsP7Q7MZva03Tfme/MSF5a6HC2xryjAM4FxPLHGqlh5VALCbywHnzs2uPoF/4G/QVXyYDDSkp5nPfig=="
+crossorigin=""></script>
 
 <!-- Load Esri Leaflet Renderers plugin to use feature service symbology -->
-<script src="https://unpkg.com/esri-leaflet-renderers@3.0.0/dist/esri-leaflet-renderers.js" integrity="sha512-tqY7QUz7UHKLqhBX1SVYBsn6EKeadkSqYXsdj3RbzZdY8jUq1t0Hi+CS7vylbMIM/jcmN4PgelBhiKvCjTJ7GQ==" crossorigin=""></script>
+<script src="https://unpkg.com/esri-leaflet-renderers@2.1.2" crossorigin=""></script>
 
 <script src='https://api.mapbox.com/mapbox.js/plugins/leaflet-fullscreen/v1.0.1/Leaflet.fullscreen.min.js'></script>
 <link href='https://api.mapbox.com/mapbox.js/plugins/leaflet-fullscreen/v1.0.1/leaflet.fullscreen.css' rel='stylesheet'/>

--- a/docs/_pages/en/dsra_scenario_map.md
+++ b/docs/_pages/en/dsra_scenario_map.md
@@ -1,7 +1,7 @@
 ---
 authorName: Natural Resources Canada
 authorUrl:
-dateModified: 2024-02-16
+dateModified: 2024-02-20
 noContentTitle: true
 pageclass: wb-prettify all-pre
 subject:
@@ -84,7 +84,8 @@ crossorigin=""></script>
       bounds, // Bounds for the tileset, set according to scenario
       legend = L.control( { position: 'bottomright' } ),
       params = new URLSearchParams( window.location.search ), // Get query paramaters
-      baseUrl = "https://riskprofiler.ca/dsra_",
+      // baseUrl = "https://riskprofiler.ca/dsra_",
+      baseUrl = "https://riskprofiler-ca.github.io/dsra_",
       shakeBaseUrl = "https://geo-api.stage.riskprofiler.ca/collections/opendrr_dsra_",
       eqScenario = params.get( 'scenario' ), // Scenario name
       shakemapProp = 'sH_PGA_max', // Property for shakemap popup
@@ -577,44 +578,25 @@ function setTileLayerStyles() {
         "acm7p0_georgiastraitfault": "dsra_acm7p0_georgiastraitfault_indicators_s",
         "acm7p3_leechriverfullfault": "dsra_acm7p3_leechriverfullfault_indicators_s",
         "sim9p0_cascadiainterfacebestfault": "dsra_sim9p0_cascadiainterfacebestfault_indicators_s",
-        "scm7p5_valdesbois":
-        "dsra_scm7p5_valdesbois_indicators_s",
-        "idm7p1_sidney":
-        "dsra_idm7p1_sidney_indicators_s",
-        "acm4p9_capilano5":
-        "dsra_acm4p9_capilano5_indicators_s",
-        "acm7p4_burwashlanding":
-        "ddsra_acm7p4_burwashlanding_indicators_s",
-        "scm5p0_montreal":
-        "dsra_scm5p0_montreal_indicators_s",
-        "scm5p5_ottawa":
-        "dsra_scm5p5_ottawa_indicators_s",
-        "acm4p9_vedderfault":
-        "dsra_acm4p9_vedderfault_indicators_s",
-        "acm5p0_georgiastraitfault":
-        "acm5p0_georgiastraitfault_indicators_s",
-        "acm5p0_mysterylake":
-        "acm5p0_mysterylake_indicators_s",
-        "acm5p2_beaufortfault":
-        "acm5p2_beaufortfault_indicators_s",
-        "acm5p2_vedderfault":
-        "acm5p2_vedderfault_indicators_s",
-        "acm5p5_southeypoint":
-        "acm5p5_southeypoint_indicators_s",
-        "acm5p7_southeypoint":
-        "acm5p7_southeypoint_indicators_s",
-        "acm7p7_queencharlottefault":
-        "acm7p7_queencharlottefault_indicators_s",
-        "acm8p0_queencharlottefault":
-        "acm8p0_queencharlottefault_indicators_s",
-        "scm5p0_burlingtontorontostructuralzone":
-        "scm5p0_burlingtontorontostructuralzone_indicators_s",
-        "scm5p0_rougebeach":
-        "scm5p0_rougebeach_indicators_s",
-        "scm5p6_gloucesterfault":
-        "scm5p6_gloucesterfault_indicators_s",
-        "scm5p9_millesilesfault":
-        "scm5p9_millesilesfault_indicators_s"
+        "scm7p5_valdesbois": "dsra_scm7p5_valdesbois_indicators_s",
+        "idm7p1_sidney": "dsra_idm7p1_sidney_indicators_s",
+        "acm4p9_georgiastraitfault": "dsra_acm4p9_georgiastraitfault_indicators_s",
+        "acm7p4_denalifault": "dsra_acm7p4_denalifault_indicators_s",
+        "scm5p0_montreal": "dsra_scm5p0_montreal_indicators_s",
+        "scm5p5_constancebay": "dsra_scm5p5_constancebay_indicators_s",
+        "acm4p9_vedderfault": "dsra_acm4p9_vedderfault_indicators_s",
+        "acm5p0_georgiastraitfault": "dsra_acm5p0_georgiastraitfault_indicators_s",
+        "acm5p0_mysterylake": "dsra_acm5p0_mysterylake_indicators_s",
+        "acm5p2_beaufortfault": "dsra_acm5p2_beaufortfault_indicators_s",
+        "acm5p2_vedderfault": "dsra_acm5p2_vedderfault_indicators_s",
+        "acm5p5_southeypoint": "dsra_acm5p5_southeypoint_indicators_s",
+        "acm5p7_southeypoint": "dsra_acm5p7_southeypoint_indicators_s",
+        "acm7p7_queencharlottefault": "dsra_acm7p7_queencharlottefault_indicators_s",
+        "acm8p0_queencharlottefault": "dsra_acm8p0_queencharlottefault_indicators_s",
+        "scm5p0_burlingtontorontostructuralzone": "dsra_scm5p0_burlingtontorontostructuralzone_indicators_s",
+        "scm5p0_rougebeach": "dsra_scm5p0_rougebeach_indicators_s",
+        "scm5p6_gloucesterfault": "dsra_scm5p6_gloucesterfault_indicators_s",
+        "scm5p9_millesilesfault": "dsra_scm5p9_millesilesfault_indicators_s"
     };
 
     const tileLayerStyleKey = tileLayerStyles[lcScenario];
@@ -651,21 +633,21 @@ function setShakeLayerStyles(z) {
             1: "dsra_idm7p1_sidney_shakemap_hexgrid_1km",
             5: "dsra_idm7p1_sidney_shakemap_hexgrid_5km"
         },
-        "acm4p9_capilano5": {
-            1: "dsra_acm4p9_capilano5_shakemap_hexgrid_1km",
-            5: "dsra_acm4p9_capilano5_shakemap_hexgrid_5km"
+        "acm4p9_georgiastraitfault": {
+            1: "dsra_acm4p9_georgiastraitfault_shakemap_hexgrid_1km",
+            5: "dsra_acm4p9_georgiastraitfault_shakemap_hexgrid_5km"
         },        
-        "acm7p4_burwashlanding": {
-            1: "dsra_acm7p4_burwashlanding_shakemap_hexgrid_1km",
-            5: "dsra_acm7p4_burwashlanding_shakemap_hexgrid_5km"
+        "acm7p4_denalifault": {
+            1: "dsra_acm7p4_denalifault_shakemap_hexgrid_1km",
+            5: "dsra_acm7p4_denalifault_shakemap_hexgrid_5km"
         },        
         "scm5p0_montreal": {
             1: "dsra_scm5p0_montreal_shakemap_hexgrid_1km",
             5: "dsra_scm5p0_montreal_shakemap_hexgrid_5km"
         },        
-        "scm5p5_ottawa": {
-            1: "dsra_scm5p5_ottawa_shakemap_hexgrid_1km",
-            5: "dsra_scm5p5_ottawa_shakemap_hexgrid_5km"
+        "scm5p5_constancebay": {
+            1: "dsra_scm5p5_constancebay_shakemap_hexgrid_1km",
+            5: "dsra_scm5p5_constancebay_shakemap_hexgrid_5km"
         },        
         "acm4p9_vedderfault": {
             1: "dsra_acm4p9_vedderfault_shakemap_hexgrid_1km",
@@ -733,7 +715,4 @@ function setShakeLayerStyles(z) {
         }
     }
 }
-
-
-
 </script>

--- a/docs/_pages/en/dsra_scenario_map.md
+++ b/docs/_pages/en/dsra_scenario_map.md
@@ -147,7 +147,12 @@ crossorigin=""></script>
     const mag = eqScenario[ 3 ] + '.' + eqScenario[ 5 ],
           full_name = title + ' - Magnitude ' + mag;
     // Replace generic title with scenario name
-    $( '#wb-cont' ).html( full_name );
+    // $( '#wb-cont' ).html( full_name );
+    {% for scenario in site.data.dsra.scenarios %}
+      if ( eqScenario === '{{ scenario.name }}' ) {
+        $( '#wb-cont' ).html( '{{ scenario.title[page.lang] }}' );
+      }
+    {% endfor %}
 
     var vectorUrl = baseUrl + lcScenario + "_indicators_s/EPSG_4326/{z}/{x}/{y}.pbf",
         shakemapUrl1 = baseUrl + lcScenario + "_shakemap_hexgrid_1km/EPSG_4326/{z}/{x}/{y}.pbf",

--- a/docs/_pages/en/index.md
+++ b/docs/_pages/en/index.md
@@ -1,7 +1,7 @@
 ---
 authorName: Natural Resources Canada
 authorUrl:
-dateModified: 2024-01-23
+dateModified: 2024-02-21
 pageclass: wb-prettify all-pre
 subject:
   en: [GV Government and Politics, Government services]

--- a/docs/_pages/fr/dsra_scenario_map.md
+++ b/docs/_pages/fr/dsra_scenario_map.md
@@ -1,7 +1,7 @@
 ---
 authorName: Natural Resources Canada
 authorUrl:
-dateModified: 2024-02-16
+dateModified: 2024-02-20
 noContentTitle: true
 pageclass: wb-prettify all-pre
 subject:
@@ -84,7 +84,8 @@ crossorigin=""></script>
       bounds, // Bounds for the tileset, set according to scenario
       legend = L.control( { position: 'bottomright' } ),
       params = new URLSearchParams( window.location.search ), // Get query paramaters
-      baseUrl = "https://riskprofiler.ca/dsra_",
+      // baseUrl = "https://riskprofiler.ca/dsra_",
+      baseUrl = "https://riskprofiler-ca.github.io/dsra_",
       shakeBaseUrl = "https://geo-api.stage.riskprofiler.ca/collections/opendrr_dsra_",
       eqScenario = params.get( 'scenario' ), // Scenario name
       shakemapProp = 'sH_PGA_max', // Property for shakemap popup
@@ -575,44 +576,25 @@ function setTileLayerStyles() {
         "acm7p0_georgiastraitfault": "dsra_acm7p0_georgiastraitfault_indicators_s",
         "acm7p3_leechriverfullfault": "dsra_acm7p3_leechriverfullfault_indicators_s",
         "sim9p0_cascadiainterfacebestfault": "dsra_sim9p0_cascadiainterfacebestfault_indicators_s",
-        "scm7p5_valdesbois":
-        "dsra_scm7p5_valdesbois_indicators_s",
-        "idm7p1_sidney":
-        "dsra_idm7p1_sidney_indicators_s",
-        "acm4p9_capilano5":
-        "dsra_acm4p9_capilano5_indicators_s",
-        "acm7p4_burwashlanding":
-        "ddsra_acm7p4_burwashlanding_indicators_s",
-        "scm5p0_montreal":
-        "dsra_scm5p0_montreal_indicators_s",
-        "scm5p5_ottawa":
-        "dsra_scm5p5_ottawa_indicators_s",
-        "acm4p9_vedderfault":
-        "dsra_acm4p9_vedderfault_indicators_s",
-        "acm5p0_georgiastraitfault":
-        "acm5p0_georgiastraitfault_indicators_s",
-        "acm5p0_mysterylake":
-        "acm5p0_mysterylake_indicators_s",
-        "acm5p2_beaufortfault":
-        "acm5p2_beaufortfault_indicators_s",
-        "acm5p2_vedderfault":
-        "acm5p2_vedderfault_indicators_s",
-        "acm5p5_southeypoint":
-        "acm5p5_southeypoint_indicators_s",
-        "acm5p7_southeypoint":
-        "acm5p7_southeypoint_indicators_s",
-        "acm7p7_queencharlottefault":
-        "acm7p7_queencharlottefault_indicators_s",
-        "acm8p0_queencharlottefault":
-        "acm8p0_queencharlottefault_indicators_s",
-        "scm5p0_burlingtontorontostructuralzone":
-        "scm5p0_burlingtontorontostructuralzone_indicators_s",
-        "scm5p0_rougebeach":
-        "scm5p0_rougebeach_indicators_s",
-        "scm5p6_gloucesterfault":
-        "scm5p6_gloucesterfault_indicators_s",
-        "scm5p9_millesilesfault":
-        "scm5p9_millesilesfault_indicators_s"
+        "scm7p5_valdesbois": "dsra_scm7p5_valdesbois_indicators_s",
+        "idm7p1_sidney": "dsra_idm7p1_sidney_indicators_s",
+        "acm4p9_georgiastraitfault": "dsra_acm4p9_georgiastraitfault_indicators_s",
+        "acm7p4_denalifault": "dsra_acm7p4_denalifault_indicators_s",
+        "scm5p0_montreal": "dsra_scm5p0_montreal_indicators_s",
+        "scm5p5_constancebay": "dsra_scm5p5_constancebay_indicators_s",
+        "acm4p9_vedderfault": "dsra_acm4p9_vedderfault_indicators_s",
+        "acm5p0_georgiastraitfault": "dsra_acm5p0_georgiastraitfault_indicators_s",
+        "acm5p0_mysterylake": "dsra_acm5p0_mysterylake_indicators_s",
+        "acm5p2_beaufortfault": "dsra_acm5p2_beaufortfault_indicators_s",
+        "acm5p2_vedderfault": "dsra_acm5p2_vedderfault_indicators_s",
+        "acm5p5_southeypoint": "dsra_acm5p5_southeypoint_indicators_s",
+        "acm5p7_southeypoint": "dsra_acm5p7_southeypoint_indicators_s",
+        "acm7p7_queencharlottefault": "dsra_acm7p7_queencharlottefault_indicators_s",
+        "acm8p0_queencharlottefault": "dsra_acm8p0_queencharlottefault_indicators_s",
+        "scm5p0_burlingtontorontostructuralzone": "dsra_scm5p0_burlingtontorontostructuralzone_indicators_s",
+        "scm5p0_rougebeach": "dsra_scm5p0_rougebeach_indicators_s",
+        "scm5p6_gloucesterfault": "dsra_scm5p6_gloucesterfault_indicators_s",
+        "scm5p9_millesilesfault": "dsra_scm5p9_millesilesfault_indicators_s"
     };
 
     const tileLayerStyleKey = tileLayerStyles[lcScenario];
@@ -649,21 +631,21 @@ function setShakeLayerStyles(z) {
             1: "dsra_idm7p1_sidney_shakemap_hexgrid_1km",
             5: "dsra_idm7p1_sidney_shakemap_hexgrid_5km"
         },
-        "acm4p9_capilano5": {
-            1: "dsra_acm4p9_capilano5_shakemap_hexgrid_1km",
-            5: "dsra_acm4p9_capilano5_shakemap_hexgrid_5km"
+        "acm4p9_georgiastraitfault": {
+            1: "dsra_acm4p9_georgiastraitfault_shakemap_hexgrid_1km",
+            5: "dsra_acm4p9_georgiastraitfault_shakemap_hexgrid_5km"
         },        
-        "acm7p4_burwashlanding": {
-            1: "dsra_acm7p4_burwashlanding_shakemap_hexgrid_1km",
-            5: "dsra_acm7p4_burwashlanding_shakemap_hexgrid_5km"
+        "acm7p4_denalifault": {
+            1: "dsra_acm7p4_denalifault_shakemap_hexgrid_1km",
+            5: "dsra_acm7p4_denalifault_shakemap_hexgrid_5km"
         },        
         "scm5p0_montreal": {
             1: "dsra_scm5p0_montreal_shakemap_hexgrid_1km",
             5: "dsra_scm5p0_montreal_shakemap_hexgrid_5km"
         },        
-        "scm5p5_ottawa": {
-            1: "dsra_scm5p5_ottawa_shakemap_hexgrid_1km",
-            5: "dsra_scm5p5_ottawa_shakemap_hexgrid_5km"
+        "scm5p5_constancebay": {
+            1: "dsra_scm5p5_constancebay_shakemap_hexgrid_1km",
+            5: "dsra_scm5p5_constancebay_shakemap_hexgrid_5km"
         },        
         "acm4p9_vedderfault": {
             1: "dsra_acm4p9_vedderfault_shakemap_hexgrid_1km",
@@ -731,7 +713,4 @@ function setShakeLayerStyles(z) {
         }
     }
 }
-
-
-
 </script>

--- a/docs/_pages/fr/dsra_scenario_map.md
+++ b/docs/_pages/fr/dsra_scenario_map.md
@@ -1,7 +1,7 @@
 ---
 authorName: Natural Resources Canada
 authorUrl:
-dateModified: 2024-02-20
+dateModified: 2024-02-21
 noContentTitle: true
 pageclass: wb-prettify all-pre
 subject:
@@ -91,9 +91,9 @@ crossorigin=""></script>
       shakemapProp = 'sH_PGA_max', // Property for shakemap popup
       scenarioProp = 'sCt_Res90_b0', // Property for popup and feature colour
       shakeCurrent = true,
-      epicenter,
+      epicentre,
       selection = 0; // Id of a selected feature
-    
+
 
   L.tileLayer( 'https://osm-{s}.gs.mil/tiles/default_pc/{z}/{x}/{y}.png', {
       subdomains: '1234',
@@ -168,7 +168,7 @@ crossorigin=""></script>
       }).on( 'load', function () {
         // Remove loading modal
         $( '#modal' ).remove();
-        epicenter.bringToFront();
+        epicentre.bringToFront();
       });
 
     var shakeLayer1km = L.vectorGrid.protobuf( shakemapUrl1, shakeTileOptions( 1 ) )
@@ -179,7 +179,7 @@ crossorigin=""></script>
       }).on( 'load', function () {
         // Remove loading modal
         $( '#modal' ).remove();
-        epicenter.bringToFront();
+        epicentre.bringToFront();
       }).on( 'click', function ( e ) {
     	  L.popup().setContent( "<strong>{% if page.lang == 'en' %}PGA: {% else %}AMS: {% endif %}</strong>" + e.layer.properties.sH_PGA_max.toLocaleString( undefined, { maximumFractionDigits: 2 }) )
           .setLatLng( e.latlng )
@@ -194,7 +194,7 @@ crossorigin=""></script>
       }).on( 'load', function () {
         // Remove loading modal
         $( '#modal' ).remove();
-        epicenter.bringToFront();
+        epicentre.bringToFront();
       }).on( 'click', function ( e ) {
     	  L.popup().setContent( "<strong>{% if page.lang == 'en' %}PGA: {% else %}AMS: {% endif %}</strong>" + e.layer.properties.sH_PGA_max.toLocaleString( undefined, { maximumFractionDigits: 2 }) )
           .setLatLng( e.latlng )
@@ -382,7 +382,7 @@ crossorigin=""></script>
         }
 
         div.innerHTML +=
-            '<br><div>🔴 <b>{% if page.lang == 'en' %}Epicenter{% else %}Épicentre{% endif %}</b></div>';
+            '<br><div>🔴 <b>{% if page.lang == 'en' %}Epicentre{% else %}Épicentre{% endif %}</b></div>';
       }
 
       else {
@@ -399,7 +399,7 @@ crossorigin=""></script>
         }
 
         div.innerHTML +=
-            '<br><div>🔴 <b>{% if page.lang == 'en' %}Epicenter{% else %}Épicentre{% endif %}</b></div>';
+            '<br><div>🔴 <b>{% if page.lang == 'en' %}Epicentre{% else %}Épicentre{% endif %}</b></div>';
       }
 
       return div;
@@ -455,122 +455,122 @@ function setBounds() {
         "acm7p0_georgiastraitfault": {
             southWest: [48.30891568684188, -129.0949439967106],
             northEast: [53.53110877480622, -117.3589501128889],
-            epicenter: [49.243365, -123.62296]
+            epicentre: [49.243365, -123.62296]
         },
         "acm7p3_leechriverfullfault": {
             southWest: [48.30891568624434, -129.0949439967106],
             northEast: [53.30903267135562, -117.4908738038378],
-            epicenter: [48.407017, -123.412134]
+            epicentre: [48.407017, -123.412134]
         },
         "sim9p0_cascadiainterfacebestfault": {
             southWest: [48.30891568684188, -139.0522010412872],
             northEast: [60.00006153221153, -114.05375826483],
-            epicenter: [48.251246, -125.215269]
+            epicentre: [48.251246, -125.215269]
         },
         "scm7p5_valdesbois": {
             southWest: [42.47260780141163, -86.54942531485392],
             northEast: [55.00064603767294, -67.44787497495167],
-            epicenter: [45.905377, -75.494669]   
+            epicentre: [45.905377, -75.494669]
         },
         "idm7p1_sidney": {
             southWest: [48.30891568684188, -129.0949439967106],
             northEast: [53.30903267135562, -117.3589501128889],
-            epicenter: [48.618961, -123.299385] 
+            epicentre: [48.618961, -123.299385]
         },
         "acm4p9_georgiastraitfault": {
             southWest: [48.30891568684188, -129.0949439967106],
             northEast: [53.53110877480622, -117.3589501128889],
-            epicenter: [49.280, -123.340] 
-        },    
+            epicentre: [49.280, -123.340]
+        },
         "acm7p4_denalifault": {
             southWest: [60.00000000710405, -141.0180731580253],
             northEast: [69.64745530351352, -123.7893248352215],
-            epicenter: [61.200 , -138.780] 
-        },  
+            epicentre: [61.200 , -138.780]
+        },
         "scm5p0_montreal": {
             southWest: [42.53884243059241, -86.54942531485392],
             northEast: [55.00064603767294, -65.94908207524423],
-            epicenter: [45.500 , -73.600] 
-        }, 
+            epicentre: [45.500 , -73.600]
+        },
         "scm5p5_constancebay": {
             southWest: [42.06164244999297, -86.54942531485392],
             northEast: [55.00064603767294, -68.38243594858385],
-            epicenter: [45.500 , -76.060] 
-        },              
+            epicentre: [45.500 , -76.060]
+        },
         "acm4p9_vedderfault": {
             southWest: [48.30891418, -127.9421387],
             northEast: [53.53110886, -116.2564392],
-            epicenter: [49.04, -122.08] 
-        },  
+            epicentre: [49.04, -122.08]
+        },
         "acm5p0_georgiastraitfault": {
             southWest: [48.30891418, -129.0949554],
             northEast: [53.53110886, -117.2290878],
-            epicenter: [49.28, -123.34] 
+            epicentre: [49.28, -123.34]
         },
         "acm5p0_mysterylake": {
             southWest: [48.30891418, -129.0949554],
             northEast: [53.53110877, -116.8056259],
-            epicenter: [49.37, -122.92] 
-        },   
+            epicentre: [49.37, -122.92]
+        },
         "acm5p2_beaufortfault": {
             southWest: [48.30891569, -129.094944],
             northEast: [53.53110877, -118.7975574],
-            epicenter: [49.33, -124.84] 
-        },    
+            epicentre: [49.33, -124.84]
+        },
         "acm5p2_vedderfault": {
             southWest: [48.30891569, -127.9421269],
             northEast: [53.53110877, -116.2564537],
-            epicenter: [49.04, -122.08] 
-        },      
+            epicentre: [49.04, -122.08]
+        },
         "acm5p5_southeypoint": {
             southWest: [48.30891569, -129.094944],
             northEast: [53.53110877, -117.4908738],
-            epicenter: [48.95, -123.61] 
-        },        
+            epicentre: [48.95, -123.61]
+        },
         "acm5p7_southeypoint": {
             southWest: [48.30891569, -129.094944],
             northEast: [53.53110877, -117.4908738],
-            epicenter: [48.95, -123.61] 
-        },     
+            epicentre: [48.95, -123.61]
+        },
         "acm7p7_queencharlottefault": {
             southWest: [50.11540505, -133.1977449],
             northEast: [56.27162148, -124.9961029],
-            epicenter: [53, -132.62] 
-        },   
+            epicentre: [53, -132.62]
+        },
         "acm8p0_queencharlottefault": {
             southWest: [49.51322353, -133.1977449],
             northEast: [58.00055135, -124.9961029],
-            epicenter: [53, -132.62] 
-        },  
+            epicentre: [53, -132.62]
+        },
         "scm5p0_burlingtontorontostructuralzone": {
             southWest: [41.68143543, -86.54942531],
             northEast: [52.29313064, -71.892560649],
-            epicenter: [43.49, -79.47] 
-        },  
+            epicentre: [43.49, -79.47]
+        },
         "scm5p0_rougebeach": {
             southWest: [41.68143543, -86.54942531],
             northEast: [55.00064604, -69.99999997],
-            epicenter: [43.78, -79.09] 
-        },  
+            epicentre: [43.78, -79.09]
+        },
         "scm5p6_gloucesterfault": {
             southWest: [42.06164245, -86.54942531],
             northEast: [55.00064604, -68.38243595],
-            epicenter: [43.78, -79.09] 
-        },  
+            epicentre: [43.78, -79.09]
+        },
         "scm5p9_millesilesfault": {
             southWest: [42.53884243, -86.54942531],
             northEast: [55.00064604, -65.94908208],
-            epicenter: [45.607, -73.82] 
-        },  
+            epicentre: [45.607, -73.82]
+        },
     };
 
     const config = scenarioConfig[lcScenario];
     if (config) {
-        const { southWest, northEast, epicenter } = config;
+        const { southWest, northEast, epicentre } = config;
 
         const bounds = L.latLngBounds(L.latLng(...southWest), L.latLng(...northEast));
-        const epicenterMarker = L.circleMarker(epicenter, circleStyle()).addTo(map);
-        map.setView(L.latLng(...epicenter), 7);
+        const epicentreMarker = L.circleMarker(epicentre, circleStyle()).addTo(map);
+        map.setView(L.latLng(...epicentre), 7);
     }
 }
 
@@ -639,71 +639,71 @@ function setShakeLayerStyles(z) {
         "acm4p9_georgiastraitfault": {
             1: "dsra_acm4p9_georgiastraitfault_shakemap_hexgrid_1km",
             5: "dsra_acm4p9_georgiastraitfault_shakemap_hexgrid_5km"
-        },        
+        },
         "acm7p4_denalifault": {
             1: "dsra_acm7p4_denalifault_shakemap_hexgrid_1km",
             5: "dsra_acm7p4_denalifault_shakemap_hexgrid_5km"
-        },        
+        },
         "scm5p0_montreal": {
             1: "dsra_scm5p0_montreal_shakemap_hexgrid_1km",
             5: "dsra_scm5p0_montreal_shakemap_hexgrid_5km"
-        },        
+        },
         "scm5p5_constancebay": {
             1: "dsra_scm5p5_constancebay_shakemap_hexgrid_1km",
             5: "dsra_scm5p5_constancebay_shakemap_hexgrid_5km"
-        },        
+        },
         "acm4p9_vedderfault": {
             1: "dsra_acm4p9_vedderfault_shakemap_hexgrid_1km",
             5: "dsra_acm4p9_vedderfault_shakemap_hexgrid_5km"
-        },        
+        },
         "acm5p0_georgiastraitfault": {
             1: "dsra_acm5p0_georgiastraitfault_shakemap_hexgrid_1km",
             5: "dsra_acm5p0_georgiastraitfault_shakemap_hexgrid_5km"
-        },        
+        },
         "acm5p0_mysterylake": {
             1: "dsra_acm5p0_mysterylake_shakemap_hexgrid_1km",
             5: "dsra_acm5p0_mysterylake_shakemap_hexgrid_5km"
-        },        
+        },
         "acm5p2_beaufortfault": {
             1: "dsra_acm5p2_beaufortfault_shakemap_hexgrid_1km",
             5: "dsra_acm5p2_beaufortfault_shakemap_hexgrid_5km"
-        },        
+        },
         "acm5p2_vedderfault": {
             1: "dsra_acm5p2_vedderfault_shakemap_hexgrid_1km",
             5: "dsra_acm5p2_vedderfault_shakemap_hexgrid_5km"
-        },        
+        },
         "acm5p5_southeypoint": {
             1: "dsra_acm5p5_southeypoint_shakemap_hexgrid_1km",
             5: "dsra_acm5p5_southeypoint_shakemap_hexgrid_5km"
-        },        
+        },
         "acm5p7_southeypoint": {
             1: "dsra_acm5p7_southeypoint_shakemap_hexgrid_1km",
             5: "dsra_acm5p7_southeypoint_shakemap_hexgrid_5km"
-        },        
+        },
         "acm7p7_queencharlottefault": {
             1: "dsra_acm7p7_queencharlottefault_shakemap_hexgrid_1km",
             5: "dsra_acm7p7_queencharlottefault_shakemap_hexgrid_5km"
-        },        
+        },
         "acm8p0_queencharlottefault": {
             1: "dsra_acm8p0_queencharlottefault_shakemap_hexgrid_1km",
             5: "dsra_acm8p0_queencharlottefault_shakemap_hexgrid_5km"
-        },    
+        },
         "scm5p0_burlingtontorontostructuralzone": {
             1: "dsra_scm5p0_burlingtontorontostructuralzone_shakemap_hexgrid_1km",
             5: "dsra_scm5p0_burlingtontorontostructuralzone_shakemap_hexgrid_5km"
-        },            
+        },
         "scm5p0_rougebeach": {
             1: "dsra_scm5p0_rougebeach_shakemap_hexgrid_1km",
             5: "dsra_scm5p0_rougebeach_shakemap_hexgrid_5km"
-        },        
+        },
         "scm5p6_gloucesterfault": {
             1: "dsra_scm5p6_gloucesterfault_shakemap_hexgrid_1km",
             5: "dsra_scm5p6_gloucesterfault_shakemap_hexgrid_5km"
-        },        
+        },
         "scm5p9_millesilesfault": {
             1: "dsra_scm5p9_millesilesfault_shakemap_hexgrid_1km",
             5: "dsra_scm5p9_millesilesfault_shakemap_hexgrid_5km"
-        },   
+        },
     };
 
     const scenarioStyles = scenarios[lcScenario];

--- a/docs/_pages/fr/dsra_scenario_map.md
+++ b/docs/_pages/fr/dsra_scenario_map.md
@@ -147,7 +147,12 @@ crossorigin=""></script>
     const mag = eqScenario[ 3 ] + '.' + eqScenario[ 5 ],
           full_name = title + ' - Magnitude ' + mag;
     // Replace generic title with scenario name
-    $( '#wb-cont' ).html( full_name );
+    // $( '#wb-cont' ).html( full_name );
+    {% for scenario in site.data.dsra.scenarios %}
+      if ( eqScenario === '{{ scenario.name }}' ) {
+        $( '#wb-cont' ).html( '{{ scenario.title[page.lang] }}' );
+      }
+    {% endfor %}
 
     var vectorUrl = baseUrl + lcScenario + "_indicators_s/EPSG_4326/{z}/{x}/{y}.pbf",
         shakemapUrl1 = baseUrl + lcScenario + "_shakemap_hexgrid_1km/EPSG_4326/{z}/{x}/{y}.pbf",

--- a/docs/_pages/fr/index.md
+++ b/docs/_pages/fr/index.md
@@ -1,7 +1,7 @@
 ---
 authorName: Natural Resources Canada
 authorUrl:
-dateModified: 2024-01-23
+dateModified: 2024-02-21
 pageclass: wb-prettify all-pre
 subject:
   en: [GV Government and Politics, Government services]

--- a/docs/_pages/index.md
+++ b/docs/_pages/index.md
@@ -1,33 +1,29 @@
 ---
-  contentTitle: Canada.ca
+  contentTitle: Earthquake Scenarios | OpenDRR
   creator:
-    en: Government of Canada, Service Canada, Citizen Service Branch, Integrated Channel Management, Web Strategies and Product Management
-    fr: Gouvernement du Canada, Service Canada, Direction générale de service aux citoyens, Gestion intégrée des modes de service, Gestion des stratégies et produits Web
+    en: Open Disaster Risk Reduction (OpenDRR) Platform, Geological Survey of Canada, Natural Resources Canada, Government of Canada
+    fr: Plateforme Open Disaster Risk Reduction (OpenDRR), Commission géologique du Canada, Ressources naturelles Canada, Gouvernement du Canada
   description:
-    en: The Government of Canada website is a single point of access to all programs, services, departments, ministries and organizations of the Government of Canada.
-    fr: Le site Web du gouvernement du Canada fournit un point d'accès complet à tous les programmes, services, départements, ministères et organismes du gouvernement du Canada.
+    en: The National Earthquake Scenario Catalogue, presents the probable shaking, damage, loss and consequences from hypothetical earthquakes that could impact Canadians.
+    fr: Le dépôt est utilisé pour l’élaboration du catalogue national de scénarios de tremblement de terre, qui présente les secousses, les dommages, les pertes et les conséquences probables de tremblements de terre hypothétiques qui pourraient frapper la population canadienne.
   lang: en
   layout: layout-splashpage
   pageclass: splash
   permalink: /
   section: message
   stylesheets:
-    - href: "https://wet-boew.github.io/themes-dist/GCWeb/css/messages.min.css"
-      integrity: "sha384-ieXF8TlFIWR7tmx2r1qZTrSieCbLCTraxu/hTRWZKzum4jiv2vtalhp+kxa8/WHe"
-      crossorigin: "anonymous"
+    - href: "https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/messages.min.css"
   subject:
-    en: Government of Canada, services
-    fr: Gouvernement du Canada, services
-  title: Canada.ca
+    en: Earthquake Scenarios
+    fr: Scénarios de séismes
+  title: Earthquake Scenarios | OpenDRR
 ---
 
-<div class="row">
-	<section class="col-xs-6 text-right">
-		<h2 class="wb-inv">Government of Canada</h2>
-		<p><a href="./en/index.html" class="btn btn-primary">English</a></p>
-	</section>
-	<section class="col-xs-6" lang="fr">
-		<h2 class="wb-inv">Gouvernement du Canada</h2>
-		<p><a href="./fr/index.html" class="btn btn-primary">Français</a></p>
-	</section>
-</div>
+<section class="col-xs-6 text-right">
+	<h2 class="">Earthquake Scenarios (OpenDRR)</h2>
+	<p><a href="./en/index.html" class="btn btn-primary">English</a></p>
+</section>
+<section class="col-xs-6" lang="fr">
+	<h2 class="">Scénarios de séismes (OpenDRR)</h2>
+	<p><a href="./fr/index.html" class="btn btn-primary">Français</a></p>
+</section>

--- a/scripts/TakeSnapshot.py
+++ b/scripts/TakeSnapshot.py
@@ -203,7 +203,7 @@ tectregionnames = {
 ### Grab Scenario Information
 epi = Point(
     float(lon), float(lat)
-)  # epicenter of scenario - want to check which source region this is in
+)  # epicentre of scenario - want to check which source region this is in
 tectonicRegion = tectregionnames[
     gsim_logic_tree_file.split('NGASa0p3weights_')[1].strip('.xml')
 ]  # get the tectonic region from gsim logic tree called

--- a/scripts/calcLikelihood.py
+++ b/scripts/calcLikelihood.py
@@ -62,8 +62,8 @@ logicweights = {
 
 
 ### Grab Scenario Information
-#epi = Point(float(lon), float(lat)) #epicenter of scenario - want to check which source region this is in
-#tectonicRegion = tectregionnames[gsim_logic_tree_file.split('NGASa0p3weights_')[1].strip('.xml')] #get the tectonic region from gsim logic tree called
+#epi = Point(float(lon), float(lat))  # epicentre of scenario - want to check which source region this is in
+#tectonicRegion = tectregionnames[gsim_logic_tree_file.split('NGASa0p3weights_')[1].strip('.xml')]  # get the tectonic region from gsim logic tree called
 
 # COMMENTED OUT ABOVE (actual code) TO SEND WORKABLE MINIMUM CODE FOR REVIEW
 # TEST SCENARIO 1 - Georgia Strait event


### PR DESCRIPTION
- **Rollback from leaflet@1.9.4 to leaflet@1.7.1**
    My previous bump to leaflet@1.9.4 broke _pages/en/dsra_scenario_map.md
    where clicking on a map tile no longer shows popup or feature table.

- **Fix remaining issues with map tiles display on interactive maps**
    - Point to https://riskprofiler-ca.github.io/ as the baseUrl
      for newly uploaded v1.4.4 tiles
    - Fix setTileLayerStyles() for some of the scenarios so the feature
      tiles are filled with the correct colour shades
    - Update setShakeLayerStyles() for the 3 renamed scenarios

- **Use scenario title as heading for interactive maps**
    for French support and for consistency with the titles used elsewhere
    on GitHub Pages and on www.riskprofiler.ca

- **Change splash page title from Canada.ca to Earthquake Scenarios**

- **Change "epicenter" to "epicentre" Canadian spelling**
    and remove trailing whitespace too

- **Gemfile: Resolve "uninitialized constant TZInfo:Timezone (NameError)"**
    that may be seen on Windows.
    
    Thanks to @Andre601 for sharing his solution on
    https://github.com/tzinfo/tzinfo/issues/144#issuecomment-1364695708

A preview version is available at <https://anthonyfok.github.io/earthquake-scenarios/>

Many thanks!
